### PR TITLE
feat: add option to import plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,26 @@ export default {
 }
 ```
 
+### Plugins
+
+You can import plugins to moment. See a list of [plugins](https://momentjs.com/docs/#/plugins/)
+
+```js
+export default {
+  buildModules: [
+    '@nuxtjs/moment'
+  ],
+  moment: {
+    plugins: [
+      'moment-strftime',
+      'moment-fquarter'
+    ]
+  }
+}
+```
+
+**Note:** Don't forget to install each plugin.
+
 ### Disable plugin
 
 This module also registers a plugin to include all needed locales as well as injecting moment as `$moment` to Vue context. You can disable this behaviour using `plugin: false`.

--- a/lib/module.js
+++ b/lib/module.js
@@ -3,7 +3,8 @@ const { resolve } = require('path')
 const defaults = {
   locales: [],
   defaultLocale: false,
-  plugin: true
+  plugin: true,
+  plugins: []
 }
 
 function momentModule (moduleOptions) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,6 +2,8 @@ import moment from 'moment'
 
 <%= options.locales.map(l => `import 'moment/locale/${l}'`).join('\n') %>
 
+<%= options.plugins.map(p => `import '${p}'`).join('\n') %>
+
 <% if(options.defaultLocale) { %>moment.locale('<%= options.defaultLocale %>')<% } %>
 
 export default (ctx, inject) => {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "eslint": "latest",
     "husky": "latest",
     "jest": "latest",
+    "moment-fquarter": "latest",
+    "moment-strftime": "latest",
     "nuxt-edge": "latest",
     "standard-version": "latest"
   },

--- a/test/fixture/plugins/nuxt.config.js
+++ b/test/fixture/plugins/nuxt.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  rootDir: __dirname,
+  render: {
+    resourceHints: false
+  },
+  buildModules: [
+    { handler: require('../../../') }
+  ],
+  moment: {
+    plugins: [
+      'moment-strftime',
+      'moment-fquarter'
+    ]
+  }
+}

--- a/test/fixture/plugins/pages/index.vue
+++ b/test/fixture/plugins/pages/index.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <p v-text="str" />
+    {{ $moment('19951225', 'YYYYMMDD').fquarter() }}
+  </div>
+</template>
+
+<script>
+export default {
+  asyncData (ctx) {
+    return {
+      str: ctx.app.$moment('19951225', 'YYYYMMDD').strftime('%m/%d/%Y')
+    }
+  }
+}
+</script>

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -1,0 +1,23 @@
+const { setup, loadConfig, get, url } = require('@nuxtjs/module-test-utils')
+
+describe('plugins', () => {
+  let nuxt
+
+  beforeAll(async () => {
+    ({ nuxt } = (await setup(loadConfig(__dirname, 'plugins'))))
+  }, 60000)
+
+  afterAll(async () => {
+    await nuxt.close()
+  })
+
+  test('render moment-strftime', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/'))
+    expect(window.document.querySelector('p').textContent).toBe('12/25/1995')
+  })
+
+  test('render moment-fquarter', async () => {
+    const html = await get('/')
+    expect(html).toContain('Q3 1995/96')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -6644,6 +6644,11 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+moment-fquarter@latest:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/moment-fquarter/-/moment-fquarter-1.0.0.tgz#90f2d8bad9047c6294ed8dd94b851ffa91c8f6db"
+  integrity sha1-kPLYutkEfGKU7Y3ZS4Uf+pHI9ts=
+
 moment-locales-webpack-plugin@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.1.0.tgz#df2f084b1ab9cb093322186b651bbed167a3a882"
@@ -6651,7 +6656,14 @@ moment-locales-webpack-plugin@^1.1.0:
   dependencies:
     lodash.difference "^4.5.0"
 
-moment@^2.24.0:
+moment-strftime@latest:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/moment-strftime/-/moment-strftime-0.5.0.tgz#0cd395058cfabb2cbdbf49a2d3758aa22093d65a"
+  integrity sha512-0gwXdJEY1nD1YMlH9nLbDl+HLMfprzfxT2+qDkl29jGgDlVHzPCdwBBN0DPgY+e3+ur7tfdngxweKYBiT80nEA==
+  dependencies:
+    moment "^2.11.2"
+
+moment@^2.11.2, moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
Resolve #41 

### New option `plugins`

You can import plugins to moment. See a list of [plugins](https://momentjs.com/docs/#/plugins/)

```js
export default {
  buildModules: [
    '@nuxtjs/moment'
  ],
  moment: {
    plugins: [
      'moment-strftime',
      'moment-fquarter'
    ]
  }
}
```