### PR TITLE
feat: improve types

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ export default {
 }
 ```
 
+### Typescript
+Add `@nuxtjs/moment` to the `types` array in your `tsconfig.json`.
+
 ## Configuration
 
 To strip all locales except `en`:

--- a/README.md
+++ b/README.md
@@ -52,8 +52,25 @@ export default {
 }
 ```
 
-### Typescript
-Add `@nuxtjs/moment` to the `types` array in your `tsconfig.json`.
+### Typescript setup
+
+Add the types to your "types" array in tsconfig.json after the `@nuxt/vue-app` entry
+
+**tsconfig.json**
+
+```json
+{
+  "compilerOptions": {
+    "types": [
+      "@nuxt/vue-app",
+      "@nuxtjs/moment"
+    ]
+  }
+}
+```
+> **Why?**
+>
+> For typescript to be aware of the additions to the nuxt `Context`, the `vue` instance and the `vuex` store, the types need to be merged via [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) by adding `@nuxtjs/moment` to your types.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ export default {
 
 ### Typescript setup
 
-Add the types to your "types" array in tsconfig.json after the `@nuxt/vue-app` entry
+Add the types to your "types" array in tsconfig.json after the `@nuxt/types` entry.
+
+:warning: Use `@nuxt/vue-app` instead of `@nuxt/types` for nuxt < 2.9. 
 
 **tsconfig.json**
 
@@ -62,7 +64,7 @@ Add the types to your "types" array in tsconfig.json after the `@nuxt/vue-app` e
 {
   "compilerOptions": {
     "types": [
-      "@nuxt/vue-app",
+      "@nuxt/types",
       "@nuxtjs/moment"
     ]
   }
@@ -70,7 +72,7 @@ Add the types to your "types" array in tsconfig.json after the `@nuxt/vue-app` e
 ```
 > **Why?**
 >
-> For typescript to be aware of the additions to the nuxt `Context`, the `vue` instance and the `vuex` store, the types need to be merged via [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) by adding `@nuxtjs/moment` to your types.
+> For typescript to be aware of the additions to the `nuxt Context`, the `vue instance` and the `vuex store`, the types need to be merged via [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) by adding `@nuxtjs/moment` to your types.
 
 ## Configuration
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -19,3 +19,10 @@ declare module 'vue/types/vue' {
     $moment(input?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean): Moment
   }
 }
+
+declare module 'vuex' {
+  interface Store<S> {
+    $moment(input?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean): Moment
+  }
+}
+  

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,28 +1,28 @@
-import { Moment, MomentFormatSpecification, MomentInput } from 'moment'
+import moment from 'moment'
 import Vue from 'vue'
 
 declare module '@nuxt/vue-app' {
   interface Context {
-    $moment(input?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean): Moment
+    $moment: typeof moment
   }
 }
 
 // Nuxt 2.9+
 declare module '@nuxt/types' {
   interface Context {
-    $moment(input?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean): Moment
+    $moment: typeof moment
   }
 }
 
 declare module 'vue/types/vue' {
   interface Vue {
-    $moment(input?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean): Moment
+    $moment: typeof moment
   }
 }
 
 declare module 'vuex' {
   interface Store<S> {
-    $moment(input?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean): Moment
+    $moment: typeof moment
   }
 }
   

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,7 +20,7 @@ declare module 'vue/types/vue' {
   }
 }
 
-declare module 'vuex' {
+declare module 'vuex/types/index' {
   interface Store<S> {
     $moment: typeof moment
   }


### PR DESCRIPTION
`$moment` is injected using nuxt `inject` method and is therefore also available in `vuex`.
This adds types to the `vuex` store.

Also no longer limit the type to `(input?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean): Moment` but use `typeof moment`.
This makes it possible to do something like `this.$moment.duration()`.

The README is updated to contain info about how to use this module with typescript.
I was wondering why `this.$moment` was untyped and found out you have to add `@nuxtjs/moment` to the `types` array in your `tsconfig.json`. Thought it would make sense to include this in the README.