### PR TITLE
feat: add default format

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,22 @@ export default {
 }
 ```
 
+### Set default format
+
+You can set a [default format](https://momentjs.com/docs/#/displaying/format/) via the `defaultFormat` option.
+
+```js
+export default {
+  buildModules: [
+    '@nuxtjs/moment'
+  ],
+  moment: {
+    // Default is 'YYYY-MM-DDTHH:mm:ssZ'
+    defaultFormat: 'dddd, MMMM Do YYYY, h:mm:ss a' // "Sunday, February 14th 2010, 3:25:50 pm"
+  }
+}
+```
+
 ### Disable plugin
 
 This module also registers a plugin to include all needed locales as well as injecting moment as `$moment` to Vue context. You can disable this behaviour using `plugin: false`.

--- a/lib/module.js
+++ b/lib/module.js
@@ -4,6 +4,7 @@ const defaults = {
   locales: [],
   defaultLocale: null,
   defaultTimezone: null,
+  defaultFormat: null,
   plugin: true,
   plugins: [],
   timezone: false

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -8,6 +8,8 @@ import moment from 'moment'
 
 <% if(options.defaultTimezone) { %>moment.tz.setDefault('<%= options.defaultTimezone %>')<% } %>
 
+<% if(options.defaultFormat) { %>moment.defaultFormat = '<%= options.defaultFormat %>'<% } %>
+
 export default (ctx, inject) => {
   ctx.$moment = moment
   inject('moment', moment)

--- a/test/default-format.test.js
+++ b/test/default-format.test.js
@@ -1,0 +1,18 @@
+const { setup, loadConfig, get } = require('@nuxtjs/module-test-utils')
+
+describe('format', () => {
+  let nuxt
+
+  beforeAll(async () => {
+    ({ nuxt } = (await setup(loadConfig(__dirname, 'default-format'))))
+  }, 60000)
+
+  afterAll(async () => {
+    await nuxt.close()
+  })
+
+  test('render', async () => {
+    const html = await get('/')
+    expect(html).toContain('test 2014-06-01')
+  })
+})

--- a/test/fixture/default-format/nuxt.config.js
+++ b/test/fixture/default-format/nuxt.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  rootDir: __dirname,
+  buildModules: [
+    { handler: require('../../../') }
+  ],
+  moment: {
+    defaultFormat: '[test] YYYY-MM-DD'
+  }
+}

--- a/test/fixture/default-format/pages/index.vue
+++ b/test/fixture/default-format/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    {{ $moment('2014-06-01T12:00:00Z').format() }}
+  </div>
+</template>


### PR DESCRIPTION
This PR adds support for the defaultFormat option to be configured in moment.js through the module options.
Added appropriate tests which passed on my machine. 

---
Fixes #73 and kept my word https://github.com/nuxt-community/moment-module/issues/73#issuecomment-948666864:
> *"I may create a PR in the future to add an option like this into the config of this module"*